### PR TITLE
fix: Junie name and Homage URL

### DIFF
--- a/website/data/assistants.js
+++ b/website/data/assistants.js
@@ -128,8 +128,8 @@ const assistants = [
       "Watch Out": "Mainly intended for small features and repetitive work"
     },    
     {
-      "Tool": "JUNIE",
-      "Homepage": "www.jetbrains.com/junie/",
+      "Tool": "Junie",
+      "Homepage": "https://www.jetbrains.com/junie/",
       "PricingLink": "https://www.jetbrains.com/junie/#pricing",
       "Code Completion": "✅",
       "Chat": "✅",


### PR DESCRIPTION
### 🛠️ Contribution Type
- [ ] New AI tool added
- [x] Update to existing tool

### 📌 Verification
Are you (check one or both):
- [ ] A maintainer of this tool?
- [x] A user of this tool?

### 📝 Description of changes
<!-- Describe what you added/updated -->
The official docs use "Junie" and in the home page link lacks "https://" which breaks the link, so added "https://".
